### PR TITLE
Add support for abstract traits and mocking of trait-methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "tomaszdurka/mocka",
   "license": "MIT",
   "require": {
-    "tomaszdurka/codegenerator": "~0.4.2"
+    "tomaszdurka/codegenerator": "~0.5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~3.7.10",

--- a/source/Mocka/AbstractClassTrait.php
+++ b/source/Mocka/AbstractClassTrait.php
@@ -18,7 +18,7 @@ trait AbstractClassTrait {
 
     /**
      * @param string $name
-     * @param array $arguments
+     * @param array  $arguments
      * @return mixed
      */
     public function __call($name, $arguments) {
@@ -47,7 +47,7 @@ trait AbstractClassTrait {
 
     /**
      * @param string $name
-     * @param array $arguments
+     * @param array  $arguments
      * @throws Exception
      * @return mixed
      */
@@ -84,7 +84,7 @@ trait AbstractClassTrait {
 
     /**
      * @param string $name
-     * @param array $arguments
+     * @param array  $arguments
      * @return mixed
      */
     private function _callMethod($name, array $arguments) {
@@ -93,6 +93,9 @@ trait AbstractClassTrait {
         }
         if ($this->_getClassMethodMockCollection()->hasMockedMethod($name)) {
             return $this->_getClassMethodMockCollection()->callMockedMethod($name, $arguments);
+        }
+        if (static::_hasTraitMethod($name)) {
+            return call_user_func_array([$this, "_mocka_{$name}"], $arguments);
         }
         if (static::_hasParentMethod($name)) {
             return call_user_func_array(array('parent', $name), $arguments);
@@ -121,8 +124,22 @@ trait AbstractClassTrait {
     }
 
     /**
+     * @param $name
+     * @return bool
+     */
+    private static function _hasTraitMethod($name) {
+        $mockClass = static::_getMockClass();
+        $reflectionsClass = new \ReflectionClass($mockClass->getParentClassName());
+        foreach ($reflectionsClass->getTraits() as $reflectionTrait) {
+            if ($reflectionTrait->hasMethod($name)) {
+                return true;
+            }
+        }
+    }
+
+    /**
      * @param string $name
-     * @param array $arguments
+     * @param array  $arguments
      * @return mixed
      */
     public static function __callStatic($name, $arguments) {
@@ -139,7 +156,7 @@ trait AbstractClassTrait {
 
     /**
      * @param string $name
-     * @param array $arguments
+     * @param array  $arguments
      * @return mixed
      */
     private static function _callStaticMethod($name, array $arguments) {

--- a/source/Mocka/AbstractClassTrait.php
+++ b/source/Mocka/AbstractClassTrait.php
@@ -95,7 +95,7 @@ trait AbstractClassTrait {
             return $this->_getClassMethodMockCollection()->callMockedMethod($name, $arguments);
         }
         if (static::_hasTraitMethod($name)) {
-            return call_user_func_array([$this, "_mocka_{$name}"], $arguments);
+            return call_user_func_array([$this, "_mockaTraitAlias_{$name}"], $arguments);
         }
         if (static::_hasParentMethod($name)) {
             return call_user_func_array(array('parent', $name), $arguments);

--- a/source/Mocka/ClassAbstractMock.php
+++ b/source/Mocka/ClassAbstractMock.php
@@ -54,7 +54,7 @@ class ClassAbstractMock {
             $trait = new TraitBlock($trait);
             foreach ($reflectionTrait->getMethods() as $reflectionMethod) {
                 if (!$reflectionMethod->isAbstract()) {
-                    $trait->addAlias($reflectionMethod->getName(), "_mocka_{$reflectionMethod->getName()}");
+                    $trait->addAlias($reflectionMethod->getName(), "_mockaTraitAlias_{$reflectionMethod->getName()}");
                 }
             }
             $class->addUse($trait);

--- a/source/Mocka/ClassMock.php
+++ b/source/Mocka/ClassMock.php
@@ -4,6 +4,7 @@ namespace Mocka;
 
 use CodeGenerator\ClassBlock;
 use CodeGenerator\PropertyBlock;
+use CodeGenerator\TraitBlock;
 
 class ClassMock {
 
@@ -98,7 +99,7 @@ class ClassMock {
         if ($this->_parentClassName) {
             $class->setParentClassName($this->_parentClassName);
         }
-        $class->addUse('\Mocka\ClassTrait');
+        $class->addUse(new TraitBlock('\Mocka\ClassTrait'));
         return $class->dump();
     }
 

--- a/tests/mocks/TraitMock.php
+++ b/tests/mocks/TraitMock.php
@@ -4,7 +4,13 @@ namespace MockaMocks;
 
 trait TraitMock {
 
+    abstract function abstractTraitMethod();
+
     public function traitMethod() {
 
+    }
+
+    public function bar () {
+        return 'traitbar';
     }
 }

--- a/tests/source/Mocka/ClassAbstractMockTest.php
+++ b/tests/source/Mocka/ClassAbstractMockTest.php
@@ -83,8 +83,8 @@ EOD;
 class $className {
 
     use $traitName {
-        traitMethod as _mocka_traitMethod;
-        bar as _mocka_bar;
+        traitMethod as _mockaTraitAlias_traitMethod;
+        bar as _mockaTraitAlias_bar;
     }
 
     use \Mocka\AbstractClassTrait;

--- a/tests/source/Mocka/ClassAbstractMockTest.php
+++ b/tests/source/Mocka/ClassAbstractMockTest.php
@@ -84,6 +84,7 @@ class $className {
 
     use $traitName {
         traitMethod as _mocka_traitMethod;
+        bar as _mocka_bar;
     }
 
     use \Mocka\AbstractClassTrait;
@@ -93,6 +94,10 @@ class $className {
     }
 
     public function traitMethod() {
+        return \$this->_callMethod(__FUNCTION__, func_get_args());
+    }
+
+    public function bar() {
         return \$this->_callMethod(__FUNCTION__, func_get_args());
     }
 

--- a/tests/source/Mocka/ClassAbstractMockTest.php
+++ b/tests/source/Mocka/ClassAbstractMockTest.php
@@ -82,9 +82,19 @@ EOD;
         $expectedMockCode = <<<EOD
 class $className {
 
-    use $traitName;
+    use $traitName {
+        traitMethod as _mocka_traitMethod;
+    }
 
     use \Mocka\AbstractClassTrait;
+
+    public function abstractTraitMethod() {
+        return \$this->_callMethod(__FUNCTION__, func_get_args());
+    }
+
+    public function traitMethod() {
+        return \$this->_callMethod(__FUNCTION__, func_get_args());
+    }
 
     public function __construct() {
         return \$this->_callMethod(__FUNCTION__, func_get_args());

--- a/tests/source/Mocka/ClassMockTest.php
+++ b/tests/source/Mocka/ClassMockTest.php
@@ -61,6 +61,17 @@ EOD;
         $classMock->mockMethod('zoo');
     }
 
+    public function testMockMethodFromTrait() {
+        $classMock = new ClassMock(null, '\\MockaMocks\\AbstractClass', null, ['\\MockaMocks\\TraitMock']);
+
+        /** @var AbstractClassTrait|AbstractClass $object */
+        $object = $classMock->newInstanceWithoutConstructor();
+        $this->assertSame('traitbar', $object->bar());
+
+        $classMock->mockMethod('bar');
+        $this->assertSame(null, $object->bar());
+    }
+
     public function testMockStaticMethod() {
         $classMock = new ClassMock(null, '\\MockaMocks\\AbstractClass');
         /** @var AbstractClass $className */


### PR DESCRIPTION
fixes #28 
depends on https://github.com/tomaszdurka/codegenerator/pull/13

Uses aliases to retain access to original implementations of trait-methods