### PR TITLE
Readd support for late static binding

### DIFF
--- a/source/Mocka/Invokables/Invokable/AbstractInvokable.php
+++ b/source/Mocka/Invokables/Invokable/AbstractInvokable.php
@@ -10,25 +10,8 @@ abstract class AbstractInvokable {
     /** @var Invocations */
     private $_invocations;
 
-    /**
-     * @param Invocation $invocation
-     */
-    abstract protected function _invoke(Invocation $invocation);
-
     public function __construct() {
         $this->_invocations = new Invocations();
-    }
-
-    /**
-     * @param mixed|null $context
-     * @param array      $arguments
-     * @return mixed|null
-     */
-    public function invoke($context, array $arguments) {
-        $invocation = new Invocation($context, $arguments);
-        $this->_invoke($invocation);
-        $this->getInvocations()->add($invocation);
-        return $invocation->getReturnValue();
     }
 
     /**

--- a/source/Mocka/Invokables/Invokable/OriginalMethodWrapperInterface.php
+++ b/source/Mocka/Invokables/Invokable/OriginalMethodWrapperInterface.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Mocka\Invokable\Invokable;
+
+interface OriginalMethodWrapperInterface {};

--- a/source/Mocka/Invokables/Invokable/Spy.php
+++ b/source/Mocka/Invokables/Invokable/Spy.php
@@ -8,30 +8,14 @@ use ReflectionFunctionAbstract;
 
 class Spy extends AbstractInvokable {
 
-    /** @var \ReflectionFunctionAbstract */
-    private $_method;
-
     /**
-     * @param ReflectionFunctionAbstract $method
+     * @param mixed $context
+     * @param array $arguments
+     * @param mixed $returnValue
      */
-    public function __construct(ReflectionFunctionAbstract $method) {
-        $this->_method = $method;
-        parent::__construct();
-    }
-
-    /**
-     * @param Invocation $invocation
-     * @throws Exception
-     */
-    protected function _invoke(Invocation $invocation) {
-        if ($this->_method instanceof \ReflectionMethod) {
-            $this->_method->setAccessible(true);
-            $result = $this->_method->invokeArgs($invocation->getContext(), $invocation->getArguments());
-        } elseif ($this->_method instanceof \ReflectionFunction) {
-            $result = $this->_method->invokeArgs($invocation->getArguments());
-        } else {
-            throw new Exception('Fatal error, method is not a ReflectionFunctionAbstract');
-        }
-        $invocation->setReturnValue($result);
+    public function addInvocation($context, $arguments, $returnValue) {
+        $invocation = new Invocation($context, $arguments);
+        $invocation->setReturnValue($returnValue);
+        $this->getInvocations()->add($invocation);
     }
 }

--- a/source/Mocka/Invokables/Invokable/Stub.php
+++ b/source/Mocka/Invokables/Invokable/Stub.php
@@ -29,7 +29,7 @@ class Stub extends AbstractInvokable {
     }
 
     /**
-     * @param int|int[] $at
+     * @param int|int[]       $at
      * @param string|\Closure $body
      * @return static
      */
@@ -43,11 +43,18 @@ class Stub extends AbstractInvokable {
         return $this;
     }
 
-    protected function _invoke(Invocation $invocation) {
-        $arguments = $invocation->getArguments();
+    /**
+     * @param mixed|null $context
+     * @param array      $arguments
+     * @return mixed|null
+     */
+    public function invoke($context, array $arguments) {
+        $invocation = new Invocation($context, $arguments);
         $closure = $this->_getClosure($this->getInvocations()->getCount());
         $result = call_user_func_array($closure, $arguments);
         $invocation->setReturnValue($result);
+        $this->getInvocations()->add($invocation);
+        return $result;
     }
 
     /**
@@ -75,5 +82,4 @@ class Stub extends AbstractInvokable {
         }
         return $closure;
     }
-
 }

--- a/source/Mocka/Overrides/MethodOverrides/AbstractOverrides.php
+++ b/source/Mocka/Overrides/MethodOverrides/AbstractOverrides.php
@@ -36,7 +36,7 @@ abstract class AbstractOverrides {
 
     /**
      * @param string $methodName
-     * @return Override
+     * @return \Mocka\Invokables\Invokable\AbstractInvokable
      * @throws Exception
      */
     public function get($methodName) {
@@ -44,7 +44,7 @@ abstract class AbstractOverrides {
         if (!$override) {
             throw new Exception('Override not found');
         }
-        return $override;
+        return $override->getInvokable();
     }
 
     /**
@@ -77,10 +77,7 @@ abstract class AbstractOverrides {
         $context = $this->_createContext($methodName);
         $this->_manager->removeByContext($context);
         
-        $classDefinition = new ClassDefinition(get_parent_class($context->getClassName()));
-        $originalMethodReflection = $classDefinition->findOriginalMethodReflection($methodName);
-        $invokable = new Spy($originalMethodReflection);
-        
+        $invokable = new Spy();
         $override = new Override($context, $invokable);
         $this->_manager->add($override);
         return $invokable;

--- a/tests/mocks/AbstractClass.php
+++ b/tests/mocks/AbstractClass.php
@@ -14,10 +14,14 @@ abstract class AbstractClass implements InterfaceMock{
     }
 
     public function bar() {
-        return 'bar';
+        return static::jar();
     }
 
     public final function zoo() {
+    }
+
+    public function getCalledClass() {
+        return get_called_class();
     }
 
     protected function _foo(){

--- a/tests/source/Mocka/ClassMockTest.php
+++ b/tests/source/Mocka/ClassMockTest.php
@@ -32,7 +32,7 @@ EOD;
         /** @var ClassMockTrait|AbstractClass $object */
         $object = $classMock->newInstanceWithoutConstructor();
 
-        $this->assertSame('bar', $object->bar());
+        $this->assertSame('jar', $object->bar());
 
         $classMock->mockMethod('bar')->set(function () {
             return 'foo';
@@ -47,13 +47,13 @@ EOD;
         /** @var ClassMockTrait|AbstractClass $object */
         $object = $classMock->newInstanceWithoutConstructor();
 
-        $this->assertSame('bar', $object->bar());
+        $this->assertSame('jar', $object->bar());
 
         $classMock->mockMethod('bar');
         $this->assertSame(null, $object->bar());
 
         $classMock->unmockMethod('bar');
-        $this->assertSame('bar', $object->bar());
+        $this->assertSame('jar', $object->bar());
     }
 
     public function testMockMethodFromTrait() {
@@ -68,6 +68,15 @@ EOD;
         $this->assertSame(null, $object->bar());
     }
 
+    public function testGetCalledClass() {
+        $factory = new ClassMockFactory();
+        $classMock = $factory->loadClassMock(null, '\\MockaMocks\\AbstractClass');
+        /** @var AbstractClass $object */
+        $object = $classMock->newInstanceWithoutConstructor();
+
+        $this->assertSame($classMock->getClassName(), $object->getCalledClass());
+    }
+
     public function testMockStaticMethod() {
         $factory = new ClassMockFactory();
         $classMock = $factory->loadClassMock(null, '\\MockaMocks\\AbstractClass');
@@ -78,6 +87,19 @@ EOD;
             return 'foo';
         });
         $this->assertSame('foo', $className::jar());
+    }
+
+    public function testMockStaticMethodCalledFromOther() {
+        $factory = new ClassMockFactory();
+        $classMock = $factory->loadClassMock(null, '\\MockaMocks\\AbstractClass');
+        /** @var AbstractClass $object */
+        $object = $classMock->newInstanceWithoutConstructor();
+
+        $this->assertSame('jar', $object->bar());
+        $classMock->mockMethod('jar')->set(function () {
+            return 'foo';
+        });
+        $this->assertSame('foo', $object->bar());
     }
 
     public function testNewInstanceConstructorArgs() {

--- a/tests/source/Mocka/ClassTraitTest.php
+++ b/tests/source/Mocka/ClassTraitTest.php
@@ -24,7 +24,7 @@ class ClassTraitTest extends \PHPUnit_Framework_TestCase {
         /** @var \MockaMocks\AbstractClass|\Mocka\Classes\ClassMockTrait $object */
         $object = $mockClass->newInstanceWithoutConstructor();
         $this->assertNull($object->foo());
-        $this->assertSame('bar', $object->bar());
+        $this->assertSame('jar', $object->bar());
 
         $mockClass->mockMethod('foo')->set(function () {
             return 'foo';

--- a/tests/source/Mocka/ClassWrapperTest.php
+++ b/tests/source/Mocka/ClassWrapperTest.php
@@ -24,6 +24,10 @@ class $className extends $parentClassName implements \Mocka\Overrides\Overridabl
         return \$this->_callMethod(__FUNCTION__, func_get_args());
     }
 
+    public function getCalledClass() {
+        return \$this->_callMethod(__FUNCTION__, func_get_args());
+    }
+
     protected function _foo() {
         return \$this->_callMethod(__FUNCTION__, func_get_args());
     }


### PR DESCRIPTION
Add support for late static binding
- rework invocation of the original methods (instead of using reflection invoke with context use array-like callables)
- rework spy to be side call instead of wrapper around original method
- add tests for proper `get_called_class` context