### PR TITLE
Pass arguments by reference when needed

### DIFF
--- a/source/Mocka/Classes/ClassMockTrait.php
+++ b/source/Mocka/Classes/ClassMockTrait.php
@@ -43,12 +43,14 @@ trait ClassMockTrait {
      * @throws Exception
      */
     private function _callMethod($name, array $arguments) {
+        foreach ($arguments as $i => $argument) {
+            $arguments[$i] = &$argument;
+        }
         $classDefinition = new ClassDefinition(__CLASS__);
         $originalMethod = $classDefinition->findOriginalMethod($name);
 
         $override = $this->getOverrides()->find($name);
-        
-        
+
         if ($override) {
             $invokable = $override->getInvokable();
             if ($invokable instanceof Spy) {
@@ -58,7 +60,7 @@ trait ClassMockTrait {
                 }
                 $invokable->addInvocation($this, $arguments, $returnValue);
                 return $returnValue;
-            } 
+            }
             if ($invokable instanceof Stub) {
                 return $invokable->invoke($this, $arguments);
             }
@@ -81,6 +83,9 @@ trait ClassMockTrait {
      * @throws Exception
      */
     private static function _callStaticMethod($name, array $arguments) {
+        foreach ($arguments as $i => $argument) {
+            $arguments[$i] = &$argument;
+        }
         $classDefinition = new ClassDefinition(get_called_class());
         $originalMethod = $classDefinition->findOriginalMethod($name);
 

--- a/source/Mocka/Invokables/Invokable/Stub.php
+++ b/source/Mocka/Invokables/Invokable/Stub.php
@@ -49,6 +49,9 @@ class Stub extends AbstractInvokable {
      * @return mixed|null
      */
     public function invoke($context, array $arguments) {
+        foreach ($arguments as $i => $argument) {
+            $arguments[$i] = &$argument;
+        }
         $invocation = new Invocation($context, $arguments);
         $closure = $this->_getClosure($this->getInvocations()->getCount());
         $result = call_user_func_array($closure, $arguments);


### PR DESCRIPTION
Replace usages of `call_user_func_array` by a helper method along the lines of [this one](http://www.php.net/manual/de/function.call-user-func-array.php#91503) to pass arguments by reference whenever required.